### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.Mateusz Koza</groupId>
+    <groupId>org.Mateusz.Koza</groupId>
     <artifactId>restful-api-demo</artifactId>
     <version>1.0-SNAPSHOT</version>
 


### PR DESCRIPTION
For now it doesn't work because given groupId is invalid.

C:\Users\Adrian\Desktop\restful-api-demo>mvn package
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] 'groupId' with value 'org.Mateusz Koza' does not match a valid id pattern. @ line 7, column 14
[ERROR] The build could not read 1 project -> [Help 1]

C:\Users\Adrian\Desktop\restful-api-demo>mvn --version
Apache Maven 3.3.3 (7994120775791599e205a5524ec3e0dfe41d4a06; 2015-04-22T13:57:37+02:00)
Maven home: C:\apache-maven-3.3.3\bin..
Java version: 1.8.0_66, vendor: Oracle Corporation
Java home: C:\Program Files\Java\jdk1.8.0_66\jre
Default locale: en_US, platform encoding: Cp1250
OS name: "windows 8.1", version: "6.3", arch: "amd64", family: "dos"
